### PR TITLE
Updated to stable Rust; fixed version of emsdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM trzeci/emscripten-slim:sdk-incoming-64bit
+FROM trzeci/emscripten-slim:sdk-tag-1.37.21-64bit
 
 # gcc is necessary to be able to compile crates that have build scripts
 RUN apt-get update && apt-get install -y curl gcc
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
 ENV PATH /root/.cargo/bin:$PATH
 
 RUN rustup target add asmjs-unknown-emscripten


### PR DESCRIPTION
Since Rust stable now supports compiling to `wasm32` and `asmjs`, this image should be updated. Also the latest version of emscripten now supports `wasm32` so the version should be fix.